### PR TITLE
Catch in queryable errors so we don't have unhandled exceptions

### DIFF
--- a/lib/Queryable.js
+++ b/lib/Queryable.js
@@ -287,7 +287,7 @@ module.exports = Queryable = require('typedef')
             var take = left < 1000 ? left : 1000;
 
             // Hit the API and incremement the page
-            q._fetch(table, take, page++, query, fields).done(function(res) {
+            q._fetch(table, take, page++, query, fields).then(function(res) {
 
                 // publish progress
                 doneLoading.notify(q._results.length);
@@ -302,6 +302,8 @@ module.exports = Queryable = require('typedef')
                 else
                     process.nextTick(loop);
 
+            }).catch(function(err) {
+                doneLoading.reject(err);
             });
         };
 


### PR DESCRIPTION
The promise chain gets broken, so if the api returns an error we have an unhandled exception rather than the error being forwarded down the promise chain.

But, it's fixed now :)